### PR TITLE
Feature/enable dll attach

### DIFF
--- a/swkotor-mod/.cargo/config.toml
+++ b/swkotor-mod/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "i686-pc-windows-msvc"

--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -3,6 +3,124 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,9 +139,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "swkotor-mod"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
+ "log",
  "windows",
 ]
 
@@ -45,13 +194,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "windows"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -64,7 +219,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -95,7 +250,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -104,7 +259,32 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -113,15 +293,21 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -131,9 +317,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -143,9 +341,21 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -155,15 +365,33 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 env_logger = "0.11.6"
 log = "0.4.25"
-windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_SystemServices"] }
+windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_System_SystemInformation", "Win32_System_SystemServices"] }

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-windows = { version="0.59.0", features=["Win32_Foundation", "Win32_System_SystemServices"] }
+env_logger = "0.11.6"
+log = "0.4.25"
+windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_SystemServices"] }

--- a/swkotor-mod/src/entry/dinput8_mock.rs
+++ b/swkotor-mod/src/entry/dinput8_mock.rs
@@ -1,0 +1,107 @@
+/// This module is meant to wrap around the fact that swkotor tries
+/// to load DINPUT8.dll before loading one from the system.
+///
+/// To make it accept our DINPUT8, the symbol "DirectInput8Create" must
+/// be found
+///
+/// But to not make swkotor crash to a segfault (or other undefined behavior
+/// ), we need to pass the function call to the actual file from the system
+/// with correct parameters and everything.
+///
+use std::ffi::{c_void, CStr, CString};
+use std::sync::OnceLock;
+use windows::Win32::Foundation::{HINSTANCE, HMODULE, MAX_PATH};
+use windows::Win32::System::SystemInformation::GetSystemDirectoryA;
+use windows::Win32::System::LibraryLoader::{LoadLibraryA, GetProcAddress};
+use windows::core::{GUID, HRESULT, PCSTR};
+
+type REFIID = *const GUID;
+type LPUNKNOWN = *mut core::ffi::c_void;
+
+// We'll store the real function pointer in a static mut for demonstration.
+// In a robust solution, you might initialize once during DllMain or similar.
+type DirectInput8CreateFn = unsafe extern "system"
+    fn(HINSTANCE, u32, *const GUID, *mut *mut c_void, *mut c_void) -> HRESULT;
+
+// This OnceLock will store our function pointer once.
+static REAL_DINPUT8_CREATE: OnceLock<DirectInput8CreateFn> = OnceLock::new();
+
+fn get_system_directory_ansi() -> Result<String, String> {
+    // Create a buffer of length MAX_PATH (260 bytes)
+    let mut buffer = [0u8; MAX_PATH as usize];
+
+    unsafe {
+        let len = GetSystemDirectoryA(Some(buffer.as_mut()));
+        if len == 0 {
+            return Err("Failed to get system directory".to_string());
+        }
+        // Convert buffer to a &CStr up to the first null.
+        let cstr = CStr::from_ptr(buffer.as_ptr() as *const i8);
+        Ok(cstr.to_string_lossy().into_owned())
+    }
+}
+
+// "system" calling convention is correct for most Windows API functions.
+#[no_mangle]
+pub extern "system" fn DirectInput8Create(
+    hinst: HINSTANCE,
+    dw_version: u32,
+    riidltf: REFIID,
+    ppv_out: *mut *mut c_void,
+    punk_outer: LPUNKNOWN,
+) -> HRESULT {
+    log::trace!("Mocking DirectInput8Create");
+
+    if REAL_DINPUT8_CREATE.get().is_none() {
+        // Load the real dinput8.dll
+        let system_dir = match get_system_directory_ansi() {
+            Err(e) => {
+                log::error!("Failed to get system directory {e}");
+                return HRESULT(-2147467259i32) // HRESULT_FROM_WIN32(E_FAIL = 0x80004005)
+            }
+            Ok(dir) => dir
+        };
+        let dll_path = CString::new(format!("{system_dir}/dinput8.dll")).unwrap();
+        let res = unsafe { LoadLibraryA(PCSTR(dll_path.as_ptr() as *const u8)) };
+
+        let real_module = match res {
+            Err(e) => {
+                log::error!("Failed to load dinput8: {e}");
+                return HRESULT(-2147024770i32); // HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND = 0x8007007E)
+            },
+            Ok(module) => module.0
+        };
+
+        if real_module == std::ptr::null_mut() {
+            // Fail if we can't load the real library
+            log::error!("Loaded dinput8, but pointer was null");
+            return HRESULT(-2147024770i32); // HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND = 0x8007007E)
+        }
+
+        let proc_name = CString::new("DirectInput8Create").unwrap();
+        let real_proc = unsafe { GetProcAddress(HMODULE(real_module), PCSTR(proc_name.as_ptr() as *const u8)) };
+        if real_proc.is_none() {
+            // Fail if not found
+            log::error!("Failed to get DirectInput8Create address");
+            return HRESULT(-2147024770i32); // HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND = 0x8007007E)
+        }
+        unsafe {
+            let real_func: DirectInput8CreateFn = std::mem::transmute(real_proc);
+            let res = REAL_DINPUT8_CREATE.set(real_func);
+            if res != Ok(()) {
+                log::error!("Failed to set real function pointer");
+                return HRESULT(-2147467259i32); // HRESULT_FROM_WIN32(E_FAIL = 0x80004005)
+            }
+        }
+    }
+
+    // Call the real function
+    if let Some(real_func) = REAL_DINPUT8_CREATE.get() {
+        unsafe {
+            (real_func)(hinst, dw_version, riidltf, ppv_out, punk_outer)
+        }
+    } else {
+        // Should never happen, but just in case
+        return HRESULT(-2147467259i32) // HRESULT_FROM_WIN32(E_FAIL = 0x80004005)
+    }
+}

--- a/swkotor-mod/src/entry/mod.rs
+++ b/swkotor-mod/src/entry/mod.rs
@@ -1,0 +1,1 @@
+pub mod dinput8_mock;

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -1,15 +1,35 @@
-use windows::{Win32::Foundation::*, Win32::System::SystemServices::*};
+pub mod entry;
+
+use windows::Win32::Foundation::HINSTANCE;
+use windows::Win32::System::SystemServices::*;
+use env_logger::{self, Env};
+use log::trace;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
+}
+
+fn setup_logging() {
+    // Dump all logs to a file. For that, we'll need a pipe to pass to env_logger.
+    let file = std::fs::File::create("swkotor-mod.log").expect("Failed to initialize logging file for piping.");
+    let mut builder = env_logger::Builder::from_env(Env::default().default_filter_or("trace"));
+    builder.target(env_logger::Target::Pipe(Box::new(file)));
+    builder.init();
+}
+
+fn attach() {
+    setup_logging();
+    trace!("Hello from the DLL!");
 }
 
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 extern "system" fn DllMain(dll_module: HINSTANCE, call_reason: u32, _: *mut ()) -> bool {
     match call_reason {
-        DLL_PROCESS_ATTACH => println!("dll attach"),
-        DLL_PROCESS_DETACH => println!("dll deattach"),
+        DLL_PROCESS_ATTACH => {
+            attach();
+        },
+        DLL_PROCESS_DETACH => (),
         _ => (),
     }
 


### PR DESCRIPTION
Not sure if you want any help in the matter, and if so, let me know.

You got me excited in your efforts and I wanted to see if I could help.

At current state, this is attachable to the swkotor process.  Install the matching win32 target with rustup, copy the created dll as `dinput8.dll` in the `swkotor.exe` directory and start the process.

At the moment, it should do nothing but log a few lines in `swkotor-mod.log` (in swkotor.exe directory). But it's a start?