### PR TITLE
util: add simple poc tools to handle memory

### DIFF
--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 env_logger = "0.11.6"
 log = "0.4.25"
-windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_System_SystemInformation", "Win32_System_SystemServices"] }
+windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod entry;
+pub mod util;
 
 use windows::Win32::Foundation::HINSTANCE;
 use windows::Win32::System::SystemServices::*;

--- a/swkotor-mod/src/util/memory_patcher.rs
+++ b/swkotor-mod/src/util/memory_patcher.rs
@@ -1,0 +1,29 @@
+use windows::Win32::System::Memory::{VirtualProtect, PAGE_PROTECTION_FLAGS, PAGE_READWRITE};
+use std::ffi::c_void;
+
+/// Overwrites `new_data` bytes at `address`, temporarily changing the page
+/// to writable if needed, then restoring the original protection.
+pub unsafe fn patch_memory(address: *mut u8, new_data: &[u8]) {
+    let mut old_protect: PAGE_PROTECTION_FLAGS = Default::default();
+    // Make memory writable
+    let _ = VirtualProtect(
+        address as *mut c_void,
+        new_data.len(),
+        PAGE_READWRITE,
+        &mut old_protect,
+    ).map_err(
+        |e| { log::error!("Failed to break memory protection"); e }
+    ).unwrap();
+
+    // Write new data
+    address.copy_from(new_data.as_ptr(), new_data.len());
+    // Restore original protection
+    let _ = VirtualProtect(
+        address as *mut c_void,
+        new_data.len(),
+        old_protect,
+        &mut old_protect,
+    ).map_err(
+        |e| { log::error!("Failed to break memory protection"); e }
+    ).unwrap();
+}

--- a/swkotor-mod/src/util/mod.rs
+++ b/swkotor-mod/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub mod needle_finder;
+pub mod memory_patcher;
+pub mod poc;

--- a/swkotor-mod/src/util/needle_finder.rs
+++ b/swkotor-mod/src/util/needle_finder.rs
@@ -1,0 +1,146 @@
+/// Utility to find a needle in a haystack, or a string in memory.
+///
+use std::{ffi::c_void, slice};
+use windows::Win32::System::Memory::{
+    VirtualProtect, VirtualQuery, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS, PAGE_NOCACHE, PAGE_PROTECTION_FLAGS, PAGE_READWRITE, PAGE_WRITECOMBINE
+};
+
+#[allow(dead_code)]
+unsafe fn remove_guard_page(address: *const c_void, size: usize) -> bool {
+    let mut old_protect: PAGE_PROTECTION_FLAGS = PAGE_PROTECTION_FLAGS::default();
+    let res = VirtualProtect(address, size, PAGE_READWRITE, &mut old_protect);
+    res.is_ok()
+}
+
+// A small utility for searching for `needle` in `haystack`.
+fn naive_mem_search(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    // Slide over haystack windows of length equal to needle
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+/// Checks if the page is accessible by default
+fn skip_memory(mbi: & MEMORY_BASIC_INFORMATION) -> bool {
+    mbi.State != MEM_COMMIT ||
+    (mbi.Protect == PAGE_NOACCESS
+    || (mbi.Protect & PAGE_GUARD) == PAGE_GUARD
+    || (mbi.Protect & PAGE_NOCACHE) == PAGE_NOCACHE
+    || (mbi.Protect & PAGE_WRITECOMBINE) == PAGE_WRITECOMBINE)
+
+}
+/// Search the current process memory for the given `needle`
+/// Returns the first address where `needle` is found, or None if not found.
+///
+/// CAUTION: This is purely a naive PoC. It may crash if pages are partially accessible.
+///
+/// - `needle`: the bytes to look for (e.g. b"dialog.tlk\0" or wide-encoded bytes).
+pub fn find_string_in_memory(needle: &[u8]) -> Option<*mut u8> {
+    let mut address = 0usize; // Start from address 0 and walk upward
+
+    loop {
+        let mut mbi = MEMORY_BASIC_INFORMATION::default();
+        // VirtualQuery will fill `mbi` with info about the region containing `address`.
+        let result = unsafe { VirtualQuery(
+            Some(address as *const _),
+            &mut mbi,
+            std::mem::size_of::<MEMORY_BASIC_INFORMATION>(),
+        )};
+
+        if result == 0 {
+            // No more regions to query
+            break;
+        }
+
+        // We only scan committed, readable pages. (Skipping free/reserved/noaccess.)
+        // A more complete approach also checks mbi.Protect, e.g., skipping PAGE_GUARD, etc.
+        if ! skip_memory(&mbi) {
+            let base = mbi.BaseAddress as usize;
+            let region_size = mbi.RegionSize;
+
+            // Construct a slice to read that memory. This is UNSAFE and can crash
+            // if the region is partially accessible or there's a guard page.
+            let slice = unsafe {
+                slice::from_raw_parts(base as *const u8, region_size)
+            };
+
+            // Search for the needle.
+            if let Some(pos) = naive_mem_search(slice, needle) {
+                let found_addr = base + pos;
+                return Some(found_addr as *mut u8);
+            }
+        }
+
+        // Move to the next region: base + region_size
+        address = mbi.BaseAddress as usize + mbi.RegionSize;
+    }
+    None
+}
+
+/// Returns all starting indices in `haystack` where `needle` is found.
+fn naive_mem_search_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    let mut results = Vec::new();
+
+    if needle.is_empty() {
+        // If needle is empty, every index is a match (ambiguous).
+        return results;
+    }
+
+    let mut start = 0;
+
+    while let Some(pos) = haystack[start..].windows(needle.len()).position(|window| window == needle) {
+        let absolute_pos = start + pos;
+        results.push(absolute_pos);
+
+        // Move `start` forward to continue searching *after* this match.
+        // You could do `+ 1` or `+ needle.len()` depending on whether you want overlapping matches.
+        start = absolute_pos + 1;
+    }
+
+    results
+}
+
+use std::mem;
+
+pub unsafe fn find_all_matches_in_memory(needle: &[u8]) -> Vec<*mut u8> {
+    let mut results = Vec::new();
+    let mut address = 0usize;
+
+    loop {
+        let mut mbi = MEMORY_BASIC_INFORMATION::default();
+
+        let result = VirtualQuery(
+            Some(address as *const _),
+            &mut mbi,
+            mem::size_of::<MEMORY_BASIC_INFORMATION>(),
+        );
+
+        if result == 0 {
+            // No more regions
+            break;
+        }
+
+        // Check if this region is committed and readable
+        if ! skip_memory(&mbi) {
+            let base = mbi.BaseAddress as usize;
+
+            let region_size = mbi.RegionSize;
+            // Construct a slice for the region
+            let slice = slice::from_raw_parts(base as *const u8, region_size);
+            // Search for all occurrences in this region
+            let offsets = naive_mem_search_all(slice, needle);
+            for offset in offsets {
+                let found_addr = base + offset;
+                results.push(found_addr as *mut u8);
+            }
+        } else {
+            log::trace!("Skipping entry at {:p} with protect {:?}", mbi.BaseAddress, mbi.Protect);
+        }
+
+        // Move to the next region
+        address = mbi.BaseAddress as usize + mbi.RegionSize;
+    }
+
+    results
+}

--- a/swkotor-mod/src/util/poc.rs
+++ b/swkotor-mod/src/util/poc.rs
@@ -1,0 +1,37 @@
+/// Module that contains some hopefully obsoleting functions that
+/// are usable for debugging.
+///
+use crate::util;
+
+#[allow(dead_code)]
+pub fn replace_mouse_button_text() {
+    unsafe {
+        let matches = util::needle_finder::find_all_matches_in_memory(b"Reverse Mouse Buttons\0");
+        for needle in &matches {
+            let new_bytes = b"Reverse Mouse Tittons";
+            log::trace!("Replacing at address {:?}", needle);
+            util::memory_patcher::patch_memory(needle.clone(), new_bytes);
+        }
+        log::trace!("Replaced {} instances", matches.len());
+        // Do a check of trying to re-find our set string
+        let matches = util::needle_finder::find_all_matches_in_memory(b"Reverse Mouse Tittons\0");
+        for needle in &matches {
+            log::trace!("Found at address {:?}", needle);
+        }
+        log::trace!("Found {} instances", matches.len());
+    }
+}
+
+#[allow(dead_code)]
+pub fn replace_hz_text() {
+    if let Some(needle) = util::needle_finder::find_string_in_memory(b"%d Hz\0") {
+        log::trace!("Needle found at address: {:?}", needle);
+        let new_bytes = b"%d Iz";
+        unsafe {
+            util::memory_patcher::patch_memory(needle, new_bytes);
+        }
+    } else {
+        log::trace!("Needle not found");
+    }
+
+}


### PR DESCRIPTION
# Summary

In order to be able to edit memory, add memory_patcher module to replace memory content with given data.

To have something concrete to edit, add needle_finder module to search for a specific byte sequence in the process memory. To be able to test it out, add a few simple poc functions for the sake of dev-verbosity.

To test it out, call `util::poc::replace_hz_text()` from `attach()`