### PR TITLE
Feature/add iat hooking

### DIFF
--- a/swkotor-mod/.editorconfig
+++ b/swkotor-mod/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+indent_style = "space"
+indent_size = 4
+max_line_length = 100

--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -62,6 +62,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +134,17 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "plthook"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563c261b7f9067cfdef77d270ace8ad769337c200509205066a27f2456d63b83"
+dependencies = [
+ "cc",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -168,11 +194,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "swkotor-mod"
 version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
+ "plthook",
  "windows",
 ]
 
@@ -198,6 +231,28 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "inventory"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +219,7 @@ name = "swkotor-mod"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "inventory",
  "log",
  "plthook",
  "windows",

--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,17 @@ dependencies = [
  "env_filter",
  "humantime",
  "log",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -137,6 +154,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mktemp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fed8fbcd01affec44ac226784c6476a6006d98d13e33bc0ca7977aaf046bd8"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "once_cell"
@@ -221,6 +247,7 @@ dependencies = [
  "env_logger",
  "inventory",
  "log",
+ "mktemp",
  "plthook",
  "windows",
 ]
@@ -247,6 +274,21 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -9,4 +9,5 @@ crate-type = ["cdylib"]
 [dependencies]
 env_logger = "0.11.6"
 log = "0.4.25"
+plthook = "0.2.2"
 windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -6,8 +6,13 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["liveqa_tests"]
+liveqa_tests = ["inventory"]
+
 [dependencies]
 env_logger = "0.11.6"
+inventory = { version = "0.3.17", optional = true }
 log = "0.4.25"
 plthook = "0.2.2"
 windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -8,11 +8,12 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["liveqa_tests"]
-liveqa_tests = ["inventory"]
+liveqa_tests = ["inventory", "mktemp"]
 
 [dependencies]
 env_logger = "0.11.6"
 inventory = { version = "0.3.17", optional = true }
 log = "0.4.25"
+mktemp = { version = "0.5.1", optional = true }
 plthook = "0.2.2"
 windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }

--- a/swkotor-mod/src/engine/mod.rs
+++ b/swkotor-mod/src/engine/mod.rs
@@ -10,6 +10,7 @@ use log::trace;
 use windows::{core::HRESULT, Win32::Foundation::HINSTANCE};
 
 use crate::system::dll_loader::{get_proc_address, load_system_library_a, DllLibrary};
+use crate::liveqa;
 
 // Holds the global state of our mod engine.
 //
@@ -59,6 +60,8 @@ fn setup_logging() {
 pub static SW_KOTOR_MOD_ENGINE: LazyLock<Mutex<SWKotorModEngine>> = LazyLock::new(|| {
     // Is this safe to do here?
     setup_logging();
+
+    liveqa::runner::run_live_qa_tests();
 
     Mutex::new(SWKotorModEngine::new())
 });

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod engine;
 pub mod liveqa;
 pub mod system;
+pub mod util;
 
 use engine::SW_KOTOR_MOD_ENGINE;
 use log::trace;

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -7,6 +7,9 @@ use engine::SW_KOTOR_MOD_ENGINE;
 use log::trace;
 use windows::Win32::Foundation::HINSTANCE;
 use windows::Win32::System::SystemServices::*;
+use crate::system::dll_loader::DllLibrary;
+
+pub const DLL_MOCK_SELF: DllLibrary = DllLibrary::Dinput8;
 
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod engine;
+pub mod liveqa;
 pub mod system;
+
 use engine::SW_KOTOR_MOD_ENGINE;
 use log::trace;
 use windows::Win32::Foundation::HINSTANCE;

--- a/swkotor-mod/src/liveqa/liveassert.rs
+++ b/swkotor-mod/src/liveqa/liveassert.rs
@@ -1,0 +1,26 @@
+/// Module to provide assertions and mechanisms to handle for the live QA tests.
+///
+
+pub(crate) type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+/// A macro that behaves like `assert!` but returns an Err(...) instead of panicking.
+#[macro_export]
+macro_rules! test_assert {
+    ($cond:expr, $($arg:tt)*) => {
+        if !$cond {
+            return Err(format!(
+                "{} at {}:{}", $($arg)*, file!(), line!()
+            ).into());
+        }
+    };
+    ($cond:expr) => {
+        if !$cond {
+            return Err(format!(
+                "Assertion failed: {} at {}:{}",
+                stringify!($cond),
+                file!(),
+                line!()
+            ).into());
+        }
+    };
+}

--- a/swkotor-mod/src/liveqa/mod.rs
+++ b/swkotor-mod/src/liveqa/mod.rs
@@ -1,0 +1,2 @@
+pub mod liveassert;
+pub mod runner;

--- a/swkotor-mod/src/liveqa/runner.rs
+++ b/swkotor-mod/src/liveqa/runner.rs
@@ -1,0 +1,120 @@
+/// Module to run the live QA tests.
+///
+
+use crate::liveqa::liveassert::Result;
+
+use inventory;
+
+/// A simple descriptor for one “live test”.
+pub struct LiveTest {
+    pub name: &'static str,
+    pub test_fn: fn() -> Result,
+}
+
+// Tell `inventory` to gather all `LiveTest` submissions in one registry.
+inventory::collect!(LiveTest);
+
+/// This macro behaves like a little attribute. It defines a function
+/// returning `crate::liveqa::liveassert::Result`, and automatically registers it.
+///
+/// Usage:
+/// ```
+///
+///live_test! {
+///    fn mytest1()
+///    {
+///        test_assert!(1 == 0, "Expected 1 == 0, but they aren't equal");
+///    }
+///}
+///
+///live_test! {
+///    fn mytest2()
+///    {
+///        test_assert!(1 == 0);
+///    }
+///}
+/// ```
+#[cfg(feature = "liveqa_tests")]
+#[macro_export]
+macro_rules! live_test {
+    (fn $fn_name:ident() $body:block) => {
+        fn $fn_name() -> crate::liveqa::liveassert::Result {
+            // Wrap the user body in a closure so we can “append” Ok(()) automatically.
+            (|| -> crate::liveqa::liveassert::Result {
+                $body
+                Ok(())
+            })()
+        }
+
+        ::inventory::submit! {
+            $crate::liveqa::runner::LiveTest {
+                name: stringify!($fn_name),
+                test_fn: $fn_name,
+            }
+        }
+    };
+}
+
+/// This macro behaves like a little attribute. It defines a function
+/// returning `crate::liveqa::liveassert::Result`, and automatically registers it.
+///
+/// Usage:
+/// ```
+/// live_test! {
+///     fn mytest() -> crate::liveqa::liveassert::Result {
+///         // do checks
+///         if 1 == 0 {
+///             return Err("1 was not 0!".to_string());
+///         }
+///         Ok(())
+///     }
+/// }
+/// ```
+#[cfg(not(feature = "liveqa_tests"))]
+macro_rules! live_test {
+    (
+       fn $fn_name:ident() -> crate::liveqa::liveassert::Result $body:block
+    ) => {
+        // Do nothing
+    };
+}
+
+/// A helper to run *all* collected live tests and print results.
+///
+/// You could export this from the DLL and call it from the host
+/// application whenever you like.
+#[cfg(feature = "liveqa_tests")]
+pub fn run_live_qa_tests() {
+    let mut error_count: usize = 0;
+    log::info!("Running {} tests", inventory::iter::<LiveTest>.into_iter().count());
+    for test in inventory::iter::<LiveTest> {
+        let outcome = (test.test_fn)();
+        match outcome {
+            Ok(()) => {
+                log::info!("LIVE TEST PASSED: {}", test.name);
+            }
+            Err(e) => {
+                log::error!("LIVE TEST FAILED: {}\n    {}", test.name, e);
+                error_count += 1;
+                // Maybe track how many fails, log them, etc.
+            }
+        }
+    }
+
+    if error_count > 0 {
+        log::error!("LiveQA tests failed. {error_count} tests failed!");
+        log::error!("The modder will not work. Shutting down.");
+        // Swkotor will make the panic disappear, but it will halt executions
+        panic!("Tests failed");
+    }
+}
+
+/// A helper to run *all* collected live tests and print results.
+///
+/// You could export this from the DLL and call it from the host
+/// application whenever you like.
+///
+/// Does nothing as `liveqa_tests` is not enabled
+#[cfg(not(feature = "liveqa_tests"))]
+pub fn run_live_qa_tests() {
+}

--- a/swkotor-mod/src/util/iat/common.rs
+++ b/swkotor-mod/src/util/iat/common.rs
@@ -1,0 +1,115 @@
+/// Utilities to help with IAT hooking
+///
+use plthook::ObjectFile;
+use windows::Win32::System::Memory::{VirtualProtect, PAGE_PROTECTION_FLAGS, PAGE_READWRITE};
+use std::{error::Error, ffi::c_void, sync::Arc};
+
+#[derive(Clone)]
+pub struct IatStoreInternal<T: Clone> {
+    pub module: String,
+    pub symbol: String,
+    iat_slot: *const T,
+    real_fn: T,
+}
+
+unsafe impl<T: Clone> Send for IatStoreInternal<T> {}
+unsafe impl<T: Clone> Sync for IatStoreInternal<T> {}
+
+/// Closer to matching multi-threading possibilities
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct IatStore<T: Clone> (Arc<IatStoreInternal<T>>);
+
+impl<T: Clone> IatStore<T> {
+    pub fn get_fn(&self) -> T {
+        return self.0.real_fn.clone()
+    }
+}
+
+impl<T: Clone> Drop for IatStoreInternal<T> {
+    /// Once dropped, return the original function so that
+    /// the original purpose will be handled. Similar as in plthook's own replace
+    fn drop(&mut self) {
+        log::trace!("Restoring old function");
+        let res = replace_function_ptr(self.iat_slot as *mut T, &self.real_fn);
+        if let Err(e) = res {
+            log::error!("Failed to restore IAT slot: {}", e);
+        }
+    }
+}
+
+/// Replace the function of iat_slot with hook_ptr.
+///
+/// To do it, open up the memory for readwrite and replace
+/// the function itself. Memory protection aversion could
+/// be overdoing it, but in case of an error, it will be
+/// clearer what happened.
+fn replace_function_ptr<T>(iat_slot: *mut T, hook_fn: &T) -> Result<(), Box<dyn Error>> {
+    unsafe {
+        let mut old_protect = PAGE_PROTECTION_FLAGS::default();
+        let size = std::mem::size_of::<*mut c_void>();
+        let _ = VirtualProtect(
+            iat_slot as *const c_void,
+            size,
+            PAGE_READWRITE,
+            &mut old_protect,
+        )?;
+
+        // Overwrite with our hook function pointer
+        *iat_slot = std::mem::transmute_copy(hook_fn);
+
+        // Restore old protection
+        let _ = VirtualProtect(
+            iat_slot as *const c_void,
+            size,
+            old_protect,
+            &mut old_protect,
+        )?;
+    }
+
+    Ok(())
+}
+
+
+/// Installs a new hook for given symbol inside the module, while storing
+/// the information in a IatStore object.
+pub fn install_plt_hook<T: Clone>(module_name: &str, symbol_name: &str, function: &T ) -> Result<IatStore<T>, Box<dyn Error>>
+{
+    let object_file = ObjectFile::open_file(module_name)?;
+    // Iterate over symbols to find the IAT slot for CreateFileA
+    for symbol in object_file.symbols() {
+        let sym_name = symbol.name.to_string_lossy();
+        if sym_name == symbol_name {
+            // or "_CreateFileA@28" on x86 if decorated
+            let iat_slot= symbol.func_address as *mut T;
+            let old_ptr = unsafe {std::mem::transmute_copy(&*iat_slot)};
+
+            // This `func_address` is the *address of the pointer*
+            // in the IAT. We must treat it as `*mut *mut c_void`
+            // so we can overwrite the pointer inside that slot.
+            log::trace!(
+                "Found {symbol_name} IAT slot at 0x{:X}, pointing to => 0x{:X}",
+                iat_slot as usize,
+                std::ptr::addr_of!(old_ptr) as usize
+            );
+
+            replace_function_ptr::<T>(iat_slot, function)?;
+            log::trace!(
+                "IAT slot updated. Symbol {symbol_name} in module {module_name} now points to => 0x{:X}",
+                std::ptr::addr_of!(*iat_slot) as usize
+            );
+
+            return Ok(IatStore(Arc::new(IatStoreInternal{
+                module: module_name.to_string(),
+                symbol: symbol_name.to_string(),
+                real_fn: old_ptr,
+                iat_slot: iat_slot as *const T
+            })))
+        }
+    }
+    Err("Correct symbol not found".to_string().into())
+}
+
+#[cfg(feature = "liveqa_tests")]
+#[path = "tests/iat_register_tests.rs"]
+mod iat_register_tests;

--- a/swkotor-mod/src/util/iat/createfile.rs
+++ b/swkotor-mod/src/util/iat/createfile.rs
@@ -1,0 +1,126 @@
+use crate::util::iat;
+
+use super::common::{install_plt_hook, IatStore};
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+use std::ffi::CStr;
+use std::error::Error;
+use windows::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+
+type CreateFileAFn = unsafe extern "system" fn(
+    lpFileName: *const i8,
+    dwDesiredAccess: u32,
+    dwShareMode: u32,
+    lpSecurityAttributes: *mut core::ffi::c_void,
+    dwCreationDisposition: u32,
+    dwFlagsAndAttributes: u32,
+    hTemplateFile: HANDLE
+) -> HANDLE;
+
+/// Store the real function pointer
+///
+/// Encapsulate this in order to safely use it, as
+/// "creating a shared reference to mutable static is discouraged". Note
+/// that the mutex only secures the store, but should not block multi-thread
+/// createfilea creation.
+///
+/// This might require a more generic wrapper around this concept to be usable
+/// elsewhere. This is hard to grasp.
+///
+static REAL_CREATEFILEA: LazyLock<Mutex<Option<IatStore<CreateFileAFn>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+fn set_real_createfilea(store: IatStore<CreateFileAFn>) -> Result<(), Box<dyn Error>> {
+    let mut guard = REAL_CREATEFILEA.lock()?;
+    *guard = Some(store);
+    Ok(())
+}
+
+fn get_real_createfilea() -> Result<IatStore<CreateFileAFn>, Box<dyn Error>> {
+    let guard = REAL_CREATEFILEA.lock()?;
+    match &*guard {
+        None => Err("Bug. No CreateFileA hook stored".into()),
+        Some(store) => Ok(store.clone()),
+    }
+}
+
+// Our hooked CreateFileA implementation
+unsafe extern "system" fn my_createfilea(
+    lp_file_name: *const i8,
+    dw_desired_access: u32,
+    dw_share_mode: u32,
+    lp_security_attrs: *mut core::ffi::c_void,
+    dw_creation_disposition: u32,
+    dw_flags_and_attrs: u32,
+    h_template_file: HANDLE
+) -> HANDLE {
+    log::trace!("CreateFileA called");
+
+    let iat_store = get_real_createfilea();
+    if let Err(e) = iat_store {
+        log::error!("Cannot run CreateFileA. {e}");
+        return INVALID_HANDLE_VALUE;
+    }
+    let iat_store = iat_store.unwrap();
+
+    let real_fn: CreateFileAFn = iat_store.get_fn();
+
+    if lp_file_name.is_null() {
+        // No file name specified. Why would windows do this..?
+        return real_fn(
+            lp_file_name,
+            dw_desired_access,
+            dw_share_mode,
+            lp_security_attrs,
+            dw_creation_disposition,
+            dw_flags_and_attrs,
+            h_template_file
+        );
+    }
+
+    let orig_filename = CStr::from_ptr(lp_file_name).to_string_lossy().into_owned().to_ascii_lowercase();
+    log::trace!("CreateFileA called for file {orig_filename}");
+    if ! orig_filename.contains("dialog.tlk") {
+        // Not our file, skip
+        return real_fn(
+            lp_file_name,
+            dw_desired_access,
+            dw_share_mode,
+            lp_security_attrs,
+            dw_creation_disposition,
+            dw_flags_and_attrs,
+            h_template_file
+        )
+    }
+
+    log::error!("dialog.tlk detected");
+    // Override the path to one we want?
+    // let new_path = r"C:\ModData\dialog_mod.tlk";
+    // let new_cstr = CString::new(new_path).unwrap();
+
+    return real_fn(
+        lp_file_name,
+        dw_desired_access,
+        dw_share_mode,
+        lp_security_attrs,
+        dw_creation_disposition,
+        dw_flags_and_attrs,
+        h_template_file
+    );
+}
+
+/// Installs the above hook to catch the opening of dialog.tlk.
+///
+/// So far, only installs it in the main .exe memory space, so
+/// any opens coming from a DLL will not be caught.
+///
+pub fn install_createfilea_hook() -> Result<(), Box<dyn Error>> {
+
+    let store = install_plt_hook::<CreateFileAFn>("swkotor.exe", "CreateFileA", &(my_createfilea as CreateFileAFn))?;
+
+    set_real_createfilea(store)?;
+
+    Ok(())
+}

--- a/swkotor-mod/src/util/iat/mod.rs
+++ b/swkotor-mod/src/util/iat/mod.rs
@@ -1,0 +1,2 @@
+mod common;
+pub mod createfile;

--- a/swkotor-mod/src/util/iat/tests/iat_register_tests.rs
+++ b/swkotor-mod/src/util/iat/tests/iat_register_tests.rs
@@ -1,0 +1,294 @@
+/// Tests that we get some response from IAT hooking
+///
+/// To know if IAT is working (somewhat), try to hook into
+/// a known function. And to be sure that we know a function
+/// exists in OUR IAT table, declare it ourselves.
+
+use crate::live_test;
+use crate::test_assert;
+
+use mktemp::Temp;
+use std::error::Error;
+use std::ffi::c_void;
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr;
+use std::ptr::null;
+use std::str::FromStr;
+use std::sync::atomic;
+use std::sync::atomic::AtomicUsize;
+use windows::Win32::Foundation::CloseHandle;
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+use super::install_plt_hook;
+
+/// The type for CreateFileA
+type CreateFileAFn = unsafe extern "system" fn(
+    lpFileName: *const i8,
+    dwDesiredAccess: u32,
+    dwShareMode: u32,
+    lpSecurityAttributes: *mut core::ffi::c_void,
+    dwCreationDisposition: u32,
+    dwFlagsAndAttributes: u32,
+    hTemplateFile: HANDLE
+) -> HANDLE;
+
+// The function that resides in the kernel32.dll, the one
+// that old C programs (including swkotor) call
+#[link(name = "kernel32")]
+extern "system" {
+    pub fn CreateFileA(
+        lpFileName: *const i8,
+        dwDesiredAccess: u32,
+        dwShareMode: u32,
+        lpSecurityAttributes: *const c_void,
+        dwCreationDisposition: u32,
+        dwFlagsAndAttributes: u32,
+        hTemplateFile: HANDLE
+    ) -> HANDLE;
+}
+
+/// Wraps the winapi CloseHandle
+fn close_handle(handle: HANDLE)
+{
+    if handle.0 == INVALID_HANDLE_VALUE.0 {
+        return;
+    }
+
+    let _ = unsafe {
+        CloseHandle(handle).or(Err("Failed to close handle"))
+    };
+}
+
+/// Struct to store the handle and call CloseHandle if needed. Th
+struct HandleDropper {
+    handle: HANDLE
+}
+
+impl Drop for HandleDropper {
+    fn drop(&mut self) {
+        if self.handle.0 != INVALID_HANDLE_VALUE.0 {
+            close_handle(self.handle);
+        }
+    }
+}
+
+// Windows constants we might need:
+const GENERIC_READ: u32       = 0x80000000;
+const FILE_SHARE_READ: u32    = 0x00000001;
+const OPEN_EXISTING: u32      = 3;
+const FILE_ATTRIBUTE_NORMAL: u32 = 0x00000080;
+
+
+/// Calls the CreateFileA as our DLL sees it.
+fn call_default_creatfilea(file_path: &Path) -> Result<HandleDropper, Box<dyn Error>> {
+    // Convert a Rust string path to a null-terminated C string
+    log::trace!("Calling the default CreateFileA");
+    let binding = file_path.to_string_lossy().to_string();
+    let path_string = binding.as_str();
+    let filename = CString::from_str(path_string)?;
+
+    // Perform the call
+    let handle = unsafe {
+        CreateFileA(
+            filename.as_ptr(),
+            GENERIC_READ,          // or some other desiredAccess
+            FILE_SHARE_READ,
+            ptr::null(),           // no security attributes
+            OPEN_EXISTING,         // or CREATE_ALWAYS, etc.
+            FILE_ATTRIBUTE_NORMAL,
+            HANDLE(null::<*mut c_void>() as *mut c_void),
+        )
+    };
+    Ok(HandleDropper {
+        handle: handle
+    })
+}
+
+fn print_function_head(addr: *const u8, len: usize) {
+    if !log::log_enabled!(log::Level::Debug) {
+        return;
+    }
+
+    let mut str = "".to_string();
+    for i in 0..len {
+        let val = unsafe { *addr.add(i) };
+        str = format!("{str} {:02X}", val);
+    }
+    log::debug!("Function bytes: {str}");
+}
+
+/// Call the pointer value of CreateFileA
+fn call_createfilea_ptr(file_path: &Path, function: *const CreateFileAFn) -> Result<HandleDropper, Box<dyn Error>> {
+    log::trace!("Calling CreateFileA via ptr");
+
+    let binding = file_path.to_string_lossy().to_string();
+    let path_string = binding.as_str();
+    let filename = CString::from_str(path_string)?;
+
+    let createfilea_ptr = function;
+    log::debug!("Calling the CreateFileA ptr at address: {:p} with content:", createfilea_ptr);
+    print_function_head(createfilea_ptr as *const u8, 16);
+
+    // Convert the pointer to our type. There is no proper way to dereference the *const T
+    let createfilea_ptr = unsafe {
+        std::mem::transmute::<usize, CreateFileAFn>(createfilea_ptr as usize)
+    };
+
+    let handle = unsafe {
+        createfilea_ptr(
+            filename.as_ptr(),
+            GENERIC_READ,          // or some other desiredAccess
+            FILE_SHARE_READ,
+            null::<*mut c_void>() as *mut c_void,           // no security attributes
+            OPEN_EXISTING,         // or CREATE_ALWAYS, etc.
+            FILE_ATTRIBUTE_NORMAL,
+            HANDLE(null::<*mut c_void>() as *mut c_void),
+        )
+    };
+
+    Ok(HandleDropper{
+        handle: handle
+    })
+}
+
+// Just call the default createfilea. This is a bad test
+// as it is a test to test tests.
+live_test! {
+    fn test_call_createfilea() {
+        let temp_file = Temp::new_file()?;
+        let handle = call_default_creatfilea(temp_file.as_path())?;
+        test_assert!(handle.handle.0 != INVALID_HANDLE_VALUE.0, "Default CreateFileA call failed");
+    }
+}
+
+// Call the default createfilea via a pointer. Only gives
+// an example for developers to handle pointer calling
+live_test! {
+    fn test_call_createfilea_ptr() {
+        let temp_file = Temp::new_file()?;
+        let handle = call_createfilea_ptr(temp_file.as_path(), CreateFileA as *const CreateFileAFn)?;
+        test_assert!(handle.handle.0 != INVALID_HANDLE_VALUE.0, "Pointer CreateFileA call failed");
+    }
+}
+
+
+// Check that the default function works after dropping.
+// conceptually relies on the above tests to make sense.
+// If this test fails, essentially any drop in the actual
+// code will cause the program to crash.
+live_test! {
+    fn test_call_createfilea_after_drop() {
+        let temp_file = Temp::new_file()?;
+        let module_name = crate::DLL_MOCK_SELF;
+        // Our hooked CreateFileA implementation. Closures
+        // cannot be used with `unsafe extern`
+        unsafe extern "system" fn test_createfilea(
+            _lp_file_name: *const i8,
+            _dw_desired_access: u32,
+            _dw_share_mode: u32,
+            _lp_security_attrs: *mut core::ffi::c_void,
+            _dw_creation_disposition: u32,
+            _dw_flags_and_attrs: u32,
+            _h_template_file: HANDLE
+        ) -> HANDLE {
+            HANDLE(null::<*mut c_void>() as *mut c_void)
+        }
+
+        let store = install_plt_hook::<CreateFileAFn>(&module_name.to_string(), "CreateFileA", &(
+            test_createfilea as CreateFileAFn
+        ))?;
+
+        drop(store);
+
+        // We will crash here if we fail
+        log::trace!("Calling call_default_creatfilea for testing");
+        let handle = call_default_creatfilea(temp_file.as_path())?;
+        log::trace!("Called call_default_creatfilea successfully");
+
+        // The mock will just return a null, so by all accounts, this
+        // should return something valid
+        test_assert!(handle.handle.0 != INVALID_HANDLE_VALUE.0, "After-drop CreateFileA call failed");
+    }
+}
+
+// Finally, replace and call the new function
+live_test! {
+    fn test_call_after_reading() {
+        let temp_file = Temp::new_file()?;
+        let module_name = crate::DLL_MOCK_SELF;
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        // The tests are not meant to be run multiple times but it's a good
+        // practice to know the state of everything at the start of a test.
+        CALL_COUNT.store(0, atomic::Ordering::Relaxed);
+
+        // Our hooked CreateFileA implementation
+        unsafe extern "system" fn test_createfilea(
+            _lp_file_name: *const i8,
+            _dw_desired_access: u32,
+            _dw_share_mode: u32,
+            _lp_security_attrs: *mut core::ffi::c_void,
+            _dw_creation_disposition: u32,
+            _dw_flags_and_attrs: u32,
+            _h_template_file: HANDLE
+        ) -> HANDLE {
+            CALL_COUNT.store(1, atomic::Ordering::Relaxed);
+            INVALID_HANDLE_VALUE
+        }
+
+        let _store = install_plt_hook::<CreateFileAFn>(&module_name.to_string(), "CreateFileA", &(
+            test_createfilea as CreateFileAFn
+        ))?;
+
+        log::trace!("Calling call_default_creatfilea for testing");
+        // The default createfilea should now be replaced. Might crash if a bug.
+        let handle = call_default_creatfilea(temp_file.as_path())?;
+        log::trace!("Called call_default_creatfilea successfully");
+
+        test_assert!(CALL_COUNT.load(atomic::Ordering::Relaxed) == 1);
+        test_assert!(handle.handle.0 == INVALID_HANDLE_VALUE.0, "Replacing CreateFileA call failed");
+    }
+}
+
+// Test that we can call the stored pointer of the original function
+live_test! {
+    fn test_call_real_fn() {
+        let temp_file = Temp::new_file()?;
+        let module_name = crate::DLL_MOCK_SELF;
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        // The tests are not meant to be run multiple times but it's a good
+        // practice to know the state of everything at the start of a test.
+        CALL_COUNT.store(0, atomic::Ordering::Relaxed);
+
+        // Our hooked CreateFileA implementation. This one should
+        // return a failure, while the real one should succeed
+        unsafe extern "system" fn test_createfilea(
+            _lp_file_name: *const i8,
+            _dw_desired_access: u32,
+            _dw_share_mode: u32,
+            _lp_security_attrs: *mut core::ffi::c_void,
+            _dw_creation_disposition: u32,
+            _dw_flags_and_attrs: u32,
+            _h_template_file: HANDLE
+        ) -> HANDLE {
+            CALL_COUNT.store(1, atomic::Ordering::Relaxed);
+            INVALID_HANDLE_VALUE
+        }
+
+        let store = install_plt_hook::<CreateFileAFn>(&module_name.to_string(), "CreateFileA", &(
+            test_createfilea as CreateFileAFn
+        ))?;
+
+        log::trace!("Calling call_createfilea_ptr for testing");
+        // The default createfilea should now be replaced. Might crash if a bug.
+        let handle = call_createfilea_ptr(temp_file.as_path(), store.get_fn() as *const CreateFileAFn)?;
+        log::trace!("Called call_createfilea_ptr successfully");
+
+        // Our hook was not called in this test, so there should not pass.
+        test_assert!(CALL_COUNT.load(atomic::Ordering::Relaxed) != 1);
+        test_assert!(handle.handle.0 != INVALID_HANDLE_VALUE.0, "Replacing CreateFileA call failed");
+    }
+}

--- a/swkotor-mod/src/util/mod.rs
+++ b/swkotor-mod/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod needle_finder;
 pub mod memory_patcher;
 pub mod poc;
+pub mod iat;

--- a/swkotor-mod/src/util/poc.rs
+++ b/swkotor-mod/src/util/poc.rs
@@ -33,5 +33,20 @@ pub fn replace_hz_text() {
     } else {
         log::trace!("Needle not found");
     }
+}
 
+/// Tries to replace the resolution string in memory. Did not
+/// seem to work.
+#[allow(dead_code)]
+pub fn replace_resolution() {
+    unsafe {
+        let matches = util::needle_finder::find_all_matches_in_memory(b"1280x1024\0");
+        for needle in &matches {
+            let new_bytes = b"3440x1440";
+            log::trace!("Replacing at address {:?}", needle);
+            util::memory_patcher::patch_memory(needle.clone(), new_bytes);
+        }
+        log::trace!("Replaced {} instances", matches.len());
+
+    }
 }


### PR DESCRIPTION
# Summary

There are two things handled by this PR:

1. Add live_qa test framework
a. It runs some tests live, as unittests are hard to handle when some features will require the DLL to be loaded somewhere
2. Add IAT hook base
a. The commits explain the details, but basically, IAT hooks will possible be required at some point for convenience (my idea is to make dialog.tlk dynamic, including screen resolutions within). This feature is in praparation for that.

# Testing

Run the live tests, plus in a temp build, call `install_createfilea_hook()` and got to see

```text
CreateFileA called
CreateFileA called for file config.txt
CreateFileA called
CreateFileA called for file .\swkotor.ini

...
```
