### PR TITLE
Feature/add textdraw poc

### DIFF
--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -117,6 +117,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +156,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
@@ -245,6 +271,8 @@ name = "swkotor-mod"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "gl",
+ "gl_generator",
  "inventory",
  "log",
  "mktemp",
@@ -511,3 +539,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"

--- a/swkotor-mod/Cargo.lock
+++ b/swkotor-mod/Cargo.lock
@@ -62,6 +62,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "cc"
 version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +93,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chlorine"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d31b1d19317b4777ec879192d3745bd97d05262b4b19cb1dda284b9d22f19"
 
 [[package]]
 name = "colorchoice"
@@ -143,6 +167,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "imgui"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed69cf982eee638cb1a2f1cf1d4b20626ea1813b7d37df6f7d3a2d5086c8cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "imgui-sys",
+ "mint",
+ "parking_lot",
+]
+
+[[package]]
+name = "imgui-opengl-renderer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e007c11a8ef4a5c42fe77942eee4e4894dc883b521955c007fece54de6f8eaca"
+dependencies = [
+ "gl_generator",
+ "imgui",
+]
+
+[[package]]
+name = "imgui-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efc4bf8f1638a573e262ce131f870226d172e986fe966a141c2c60602589b71"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "chlorine",
+ "mint",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +249,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mktemp"
@@ -195,6 +270,29 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "plthook"
@@ -223,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -261,10 +368,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "swkotor-mod"
@@ -273,6 +392,8 @@ dependencies = [
  "env_logger",
  "gl",
  "gl_generator",
+ "imgui",
+ "imgui-opengl-renderer",
  "inventory",
  "log",
  "mktemp",

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -12,8 +12,12 @@ liveqa_tests = ["inventory", "mktemp"]
 
 [dependencies]
 env_logger = "0.11.6"
+gl = "0.14.0"
 inventory = { version = "0.3.17", optional = true }
 log = "0.4.25"
 mktemp = { version = "0.5.1", optional = true }
 plthook = "0.2.2"
 windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }
+
+[build-dependencies]
+gl_generator = "0.14.0"

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -13,11 +13,13 @@ liveqa_tests = ["inventory", "mktemp"]
 [dependencies]
 env_logger = "0.11.6"
 gl = "0.14.0"
+imgui = "0.9.0"
+imgui-opengl-renderer = "0.12.1"
 inventory = { version = "0.3.17", optional = true }
 log = "0.4.25"
 mktemp = { version = "0.5.1", optional = true }
 plthook = "0.2.2"
-windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Graphics", "Win32_Graphics_OpenGL", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }
+windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Graphics", "Win32_Graphics_Gdi", "Win32_Graphics_OpenGL", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/swkotor-mod/Cargo.toml
+++ b/swkotor-mod/Cargo.toml
@@ -17,7 +17,7 @@ inventory = { version = "0.3.17", optional = true }
 log = "0.4.25"
 mktemp = { version = "0.5.1", optional = true }
 plthook = "0.2.2"
-windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }
+windows = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Graphics", "Win32_Graphics_OpenGL", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading"] }
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/swkotor-mod/build.rs
+++ b/swkotor-mod/build.rs
@@ -1,0 +1,23 @@
+use std::{env, fs::File, path::Path};
+
+use gl_generator::{Api, Fallbacks, Profile, Registry, StaticGenerator};
+
+fn build_opengl_bindings() {
+    let dest: String = env::var("OUT_DIR").unwrap();
+    let mut file = File::create(&Path::new(&dest).join("gl_bindings_2_1.rs")).unwrap();
+
+    let registry = Registry::new(
+        Api::Gl,
+        (2, 1), // or (3,2) with Profile::Compatibility
+        Profile::Compatibility,
+        Fallbacks::All,
+        [],
+    );
+
+    // Then generate bindings that include the old fixed-function pipeline:
+    registry.write_bindings(StaticGenerator, &mut file).unwrap();
+}
+
+fn main() {
+    build_opengl_bindings();
+}

--- a/swkotor-mod/src/graphics/glstate.rs
+++ b/swkotor-mod/src/graphics/glstate.rs
@@ -1,0 +1,96 @@
+/// Module to handle gl state
+///
+/// There is a high chance that any renderings that happen
+/// break the opengl state. Broken state means that there
+/// will be graphical glitches. To combat this, store the
+/// state and pop it after any operations
+
+/// Holder for the glstate waiting for drop
+///
+/// Stores the state until the consumer drops it, restoring
+/// OpenGL state.
+pub struct GLStateStore {
+    // Add fields to store OpenGL state here
+    // For example:
+    blend: bool,
+    depth_test: bool,
+    scissor_test: bool,
+    viewport: [i32; 4],
+}
+
+impl GLStateStore {
+    /// Save the current OpenGL state
+    pub fn save() -> Self {
+        let mut viewport = [0; 4];
+        unsafe {
+            gl::GetIntegerv(gl::VIEWPORT, viewport.as_mut_ptr());
+        }
+        GLStateStore {
+            blend: unsafe { gl::IsEnabled(gl::BLEND) == gl::TRUE },
+            depth_test: unsafe { gl::IsEnabled(gl::DEPTH_TEST) == gl::TRUE },
+            scissor_test: unsafe { gl::IsEnabled(gl::SCISSOR_TEST) == gl::TRUE },
+            viewport,
+        }
+    }
+
+    /// QoL function to get viewport sizes
+    ///
+    /// As we must have it stored, it can be more convenient to get the
+    /// full viewport with this function.
+    ///
+    /// # Returns
+    ///
+    /// viewport size (x,y)
+    ///
+    pub fn get_viewport(&self) -> (f32, f32) {
+        (self.viewport[2] as f32, self.viewport[3] as f32)
+    }
+
+    /// Restore the saved OpenGL state
+    fn restore(&self) {
+        if self.blend {
+            unsafe { gl::Enable(gl::BLEND) };
+        } else {
+            unsafe { gl::Disable(gl::BLEND) };
+        }
+
+        if self.depth_test {
+            unsafe { gl::Enable(gl::DEPTH_TEST) };
+        } else {
+            unsafe { gl::Disable(gl::DEPTH_TEST) };
+        }
+
+        if self.scissor_test {
+            unsafe { gl::Enable(gl::SCISSOR_TEST) };
+        } else {
+            unsafe { gl::Disable(gl::SCISSOR_TEST) };
+        }
+
+        unsafe {
+            gl::Viewport(
+                self.viewport[0],
+                self.viewport[1],
+                self.viewport[2],
+                self.viewport[3],
+            );
+        }
+    }
+}
+
+impl Drop for GLStateStore {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+/// Store the state in OpenGL
+///
+/// When we do rendering, there is a high chance that the
+pub fn store_gl_state() -> GLStateStore {
+    GLStateStore::save()
+}
+
+/// Manually restore the OpenGL state
+pub fn restore_gl_state(store: GLStateStore) {
+    drop(store)
+}

--- a/swkotor-mod/src/graphics/mod.rs
+++ b/swkotor-mod/src/graphics/mod.rs
@@ -30,7 +30,6 @@ pub struct GlContextStorage {
     context: HGLRC,
 }
 
-
 unsafe impl Send for GlContextStorage {}
 unsafe impl Sync for GlContextStorage {}
 

--- a/swkotor-mod/src/graphics/mod.rs
+++ b/swkotor-mod/src/graphics/mod.rs
@@ -1,5 +1,6 @@
 /// Module to house the OpenGL bindings and related generic
 /// functions.
+pub mod glstate;
 pub mod opengl_bindings;
 pub mod rendering;
 

--- a/swkotor-mod/src/graphics/mod.rs
+++ b/swkotor-mod/src/graphics/mod.rs
@@ -1,3 +1,175 @@
 /// Module to house the OpenGL bindings and related generic
 /// functions.
 pub mod opengl_bindings;
+pub mod rendering;
+
+use rendering::Rendable;
+use std::sync::Mutex;
+use std::{
+    error::Error,
+    ffi::{c_void, CString},
+};
+use windows::Win32::Graphics::OpenGL::HGLRC;
+use windows::{
+    core::PCSTR,
+    Win32::{
+        Graphics::OpenGL::{wglGetCurrentContext, wglGetProcAddress},
+        System::LibraryLoader::{GetModuleHandleA, GetProcAddress},
+    },
+};
+
+use crate::util::iat::swapbuffers::hook_swapbuffers;
+use std::sync::Arc;
+
+/// Struct to store glContext
+///
+/// Will be used for comparisons.
+#[derive(Clone, Copy)]
+pub struct GlContextStorage {
+    context: HGLRC,
+}
+
+
+unsafe impl Send for GlContextStorage {}
+unsafe impl Sync for GlContextStorage {}
+
+impl GlContextStorage {
+    fn valid_context(&self) -> bool {
+        !self.context.is_invalid()
+    }
+}
+
+impl PartialEq for GlContextStorage {
+    fn eq(&self, other: &Self) -> bool {
+        self.context.0 == other.context.0
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        !self.eq(other)
+    }
+}
+
+/// Get the OpenGL context storage object
+///
+/// As is, it can just be used as an identifier on if the context
+/// matches with another one.
+///
+pub fn get_gl_context() -> GlContextStorage {
+    GlContextStorage {
+        context: unsafe { wglGetCurrentContext() },
+    }
+}
+
+/// Check if the OpenGL context is ready for rendering.
+///
+/// During startup movies and loading screens the GL context
+/// might not be available. This should be called before trying any
+/// rendering operations. Just to be safe.
+///
+pub fn context_available() -> bool {
+    let invalid_context = unsafe { wglGetCurrentContext() }.is_invalid();
+    !invalid_context
+}
+
+pub struct RendingStore {
+    rendable: Arc<Mutex<Box<dyn Rendable + Send + Sync>>>,
+}
+
+/// The main generic initialization function to enable rendering
+///
+/// Specifically for OpenGL, we need to be able to setup context
+/// for rendering for our own module. The basic is that this sets
+/// up opengl for rendering and sets up a hook to be run for each
+/// frame. This allows us to display items over the game, as we
+/// are doing it last.
+///
+/// Note. One trick about this is that it IAT hooks to the SwapBuffer.
+/// Then on the first frame (and when it absolutely has valid context),
+/// it will enable drawing.
+///
+/// Note that an improvement would be to hook onto `wglMakeCurrent` or
+/// similar that are called when a context is created. But these are
+/// not yet tested.
+///
+/// # Parameters
+///
+/// * init_cb: Callback function that will be called once per starting
+///            rendering. Should be used for one-time initialization of
+///            rendering specific contexts/variables
+/// * per_frame_cb: Callback called per-frame. Not that slow processing
+///                 will equally drop FPS of the game.
+///
+///
+pub fn initialize_pending_setup_rendering(
+    rendable: Box<dyn Rendable + Send + Sync>,
+) -> RendingStore {
+    let rendable = RendingStore {
+        rendable: Arc::new(Mutex::new(rendable)),
+    };
+
+    {
+        let rendable_clone = Arc::clone(&rendable.rendable);
+        let res = hook_swapbuffers(Box::new({
+            move || {
+                let mut rendable = rendable_clone.lock().unwrap();
+                rendable.per_frame();
+            }
+        }));
+        if let Err(e) = res {
+            log::error!("Failed to hook swapbuffers: {:?}", e);
+        }
+    }
+
+    rendable
+}
+
+/// Handles module loading as required by opengl
+///
+/// There are a few places where this is needed when using different
+/// implementations. Provide a common mechanism here.
+///
+pub fn handle_load_with(module_name: &str) -> *const c_void {
+    let cstr = CString::new(module_name).unwrap();
+    let res = unsafe { wglGetProcAddress(PCSTR(cstr.as_ptr() as *const u8)) };
+
+    if let Some(p) = res {
+        // Function found, no need to fallback.
+        return p as *const c_void;
+    }
+
+    // Fall back. Apparently, in case of opengl, this is good practice. No idea how...
+    let module = unsafe { GetModuleHandleA(PCSTR::from_raw("opengl32.dll\0".as_ptr())) };
+    if module.is_err() {
+        log::trace!("Failed to load module {module_name}");
+        return std::ptr::null();
+    }
+
+    let module = module.unwrap();
+    let res = unsafe { GetProcAddress(module, PCSTR(cstr.as_ptr() as *const u8)) };
+    if res.is_none() {
+        log::trace!("Failed to load module {module_name}");
+        return std::ptr::null();
+    }
+    res.unwrap() as *const c_void
+}
+
+/// The function that should be called when having a new OpenGL context
+///
+/// There might be some misinformation here.
+///
+/// The OpenGL context requires the setup to be run every time. This
+/// enables the functions from the module to be run against the current
+/// context.
+///
+pub fn setup_rendering() -> Result<(), Box<dyn Error>> {
+    if !context_available() {
+        // No context yet ready
+        return Err("No OpenGL context yet".into());
+    }
+
+    // somewhere after you have a valid OpenGL context
+    log::trace!("Trying to enable drawing with OpenGL. Calling load_with");
+    gl::load_with(|s| handle_load_with(s));
+    log::trace!("Successfully did not crash when calling load_with");
+    Ok(())
+}

--- a/swkotor-mod/src/graphics/mod.rs
+++ b/swkotor-mod/src/graphics/mod.rs
@@ -1,0 +1,3 @@
+/// Module to house the OpenGL bindings and related generic
+/// functions.
+pub mod opengl_bindings;

--- a/swkotor-mod/src/graphics/opengl_bindings.rs
+++ b/swkotor-mod/src/graphics/opengl_bindings.rs
@@ -1,0 +1,11 @@
+// Module to hold the generated opengl functions.
+//
+// As we are using an old version of opengl with
+// the game, we generate the bindings in build.rs
+// import them here, binding the path to this module.
+//
+// In the future, this module may hold some compatibility
+// fixes if needed.
+//
+
+include!(concat!(env!("OUT_DIR"), "/gl_bindings_2_1.rs"));

--- a/swkotor-mod/src/graphics/rendering.rs
+++ b/swkotor-mod/src/graphics/rendering.rs
@@ -1,0 +1,153 @@
+/// Utilities and traits that are usable for general rendering
+///
+use std::error::Error;
+use std::os::raw::c_void;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+use windows::Win32::Graphics::OpenGL::wglGetCurrentContext;
+
+use crate::graphics::get_gl_context;
+use crate::graphics::setup_rendering;
+
+use super::glstate::store_gl_state;
+use super::GlContextStorage;
+
+/// Trait needed to setup rendering
+///
+/// Handles all different states and quirks that are needed
+/// for Kotor rendering in the current hook system
+///
+/// dyn-compatible
+///
+pub trait Rendable {
+    /// Handle the setup for rending the given object
+    ///
+    /// This method should be callable multiple times
+    /// per process. This is because kotor drops the
+    /// OpenGL context when minimized or when playing a
+    /// video. After being restored to the game, setup
+    /// will be called again.
+    ///
+    fn setup(self: &mut Self) -> Result<(), Box<dyn Error>>;
+
+    /// The render function for the actual render work
+    ///
+    /// Called per frame after the game's own rendering,
+    /// allowing drawing on top of it.
+    ///
+    /// For convenience, the viewport dimensions are passed here.
+    ///
+    /// Handling context checks and gl state checks is done
+    /// by the trait outside of this function. See `per_frame`
+    ///
+    fn render(self: &mut Self, viewport_width: f32, viewport_height: f32);
+
+    /// Called when the OpenGL context is lost
+    ///
+    /// When called, OpenGL context was lost, so it would
+    /// be smart to drop all things that are gl context
+    /// based/dependant.
+    ///
+    fn deinit(self: &mut Self);
+
+    /// The function called per-frame
+    ///
+    /// Handles the logic of running normal operation and
+    /// setting up when needed.
+    ///
+    fn per_frame(self: &mut Self) {
+        let mut initialization_guard = state_guard();
+        let (initialized, stored_gl_context) = *initialization_guard;
+
+        let current_gl_context = get_gl_context();
+
+        if !current_gl_context.valid_context() {
+            // No point in trying anything if there is no context.
+            // SWKotor might drop the context, it's a bit unclear.
+            return;
+        }
+
+        match (
+            initialized,
+            context_eq(&current_gl_context, &stored_gl_context),
+        ) {
+            (false, false) => {
+                let res = setup_rendering();
+                if let Err(e) = res {
+                    log::error!("Rendering setup failed: {}", e);
+                    return;
+                }
+
+                log::trace!("Got context. Setup.");
+                let res = self.setup();
+                if let Err(e) = res {
+                    log::error!("Rendering setup failed: {}", e);
+                    return;
+                }
+
+                *initialization_guard = (true, Some(get_gl_context()));
+            }
+            (true, false) => {
+                // Context has disappeared on us. Deinitialize and fix on
+                // next loop.
+                // Context will most likely be dropped when
+                // 1. Minimizing window
+                // 2. A video is playing
+                // At this point, there is no guarantee that we are running
+                // in any context. Hence redo it on next frame.
+                log::trace!("Lost context. Deinit.");
+                self.deinit();
+                *initialization_guard = (false, None);
+                return;
+            }
+            // We've just received context. Setup
+            (false, true) => {
+                log::error!(
+                    "Bug. We have a context but we are not initialized. Should be impossible"
+                );
+                panic!("Bug. We have a context but we are not initialized");
+            }
+            // Normal rending operation. Just go on
+            (true, true) => (),
+        }
+
+        log::trace!("Render called, context ptr: {:p}", unsafe {
+            wglGetCurrentContext().0 as *const c_void
+        });
+
+        let state_store = store_gl_state();
+        let (width, height) = state_store.get_viewport();
+        self.render(width, height);
+    }
+}
+
+/// Just a helper function to make other code more readable
+fn context_eq(lhv: &GlContextStorage, opt_rhv: &Option<GlContextStorage>) -> bool {
+    match opt_rhv {
+        None => false,
+        Some(rhv) => lhv == rhv,
+    }
+}
+
+/// Mutex guard to provide a state and mutex for the above functions
+///
+/// Kotor does single thread rendering, but any hooked function
+/// should not be trusted to hold data. In order to
+/// not make this difficult for consumer, have a global
+/// mutex stored here.
+///
+/// That, plus the single threaded part is a bit questionable.
+///
+/// Also, the state does not need to be here. But for our modding
+/// purposes, it should be fine.
+///
+fn state_guard() -> std::sync::MutexGuard<'static, (bool, Option<GlContextStorage>)> {
+    static GUARD: LazyLock<Mutex<(bool, Option<GlContextStorage>)>> =
+        LazyLock::new(|| Mutex::new((false, None)));
+
+    match GUARD.lock() {
+        Ok(guard) => guard,
+        Err(_) => panic!("Failed to acquire rendering lock"),
+    }
+}

--- a/swkotor-mod/src/lib.rs
+++ b/swkotor-mod/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod engine;
+pub mod graphics;
 pub mod liveqa;
 pub mod system;
 pub mod util;

--- a/swkotor-mod/src/util/iat/common.rs
+++ b/swkotor-mod/src/util/iat/common.rs
@@ -30,7 +30,11 @@ impl<T: Clone> Drop for IatStoreInternal<T> {
     /// Once dropped, return the original function so that
     /// the original purpose will be handled. Similar as in plthook's own replace
     fn drop(&mut self) {
-        log::trace!("Restoring symbol {} function from module {}", self.symbol, self.module);
+        log::trace!(
+            "Restoring symbol {} function from module {}",
+            self.symbol,
+            self.module
+        );
         let res = replace_function_ptr(self.iat_slot as *mut T, &self.real_fn);
         if let Err(e) = res {
             log::error!("Failed to restore IAT slot: {}", e);

--- a/swkotor-mod/src/util/iat/mod.rs
+++ b/swkotor-mod/src/util/iat/mod.rs
@@ -1,2 +1,3 @@
 mod common;
 pub mod createfile;
+pub mod swapbuffers;

--- a/swkotor-mod/src/util/iat/swapbuffers.rs
+++ b/swkotor-mod/src/util/iat/swapbuffers.rs
@@ -1,0 +1,89 @@
+use std::{
+    error::Error,
+    sync::{LazyLock, Mutex},
+};
+/// A module to do IAT hook to SwapBuffers
+///
+/// This module is used to do IAT hook to SwapBuffers function in GDI32.dll.
+/// Apparently, swkotor does not interface to the wglSpySwapBuffers function,
+/// so we have to do IAT hook to SwapBuffers function in GDI32.dll.
+///
+/// This provides a per-frame hook into the rendering pipeline.
+use windows::Win32::Foundation::{BOOL, FALSE, HANDLE};
+
+use super::common::{install_plt_hook, IatStore};
+
+type HDC = HANDLE;
+
+type SwapBuffersFn = unsafe extern "system" fn(hdc: HDC) -> BOOL;
+
+pub type SwapbufferCallback = Box<dyn FnMut() + Send + Sync>;
+
+/// Struct that holds the IatStore and
+struct SwapBufferIatContext {
+    iat_store: IatStore<SwapBuffersFn>,
+    iat_callback: SwapbufferCallback,
+}
+unsafe impl Send for SwapBufferIatContext {}
+unsafe impl Sync for SwapBufferIatContext {}
+
+impl SwapBufferIatContext {
+    fn run_real_function(&self, hdc: HDC) -> BOOL {
+        let func = self.iat_store.get_fn();
+        unsafe { func(hdc) }
+    }
+
+    fn run_callback(&mut self) {
+        (self.iat_callback)()
+    }
+}
+
+static REAL_SWAPBUFFERS: LazyLock<Mutex<Option<SwapBufferIatContext>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+fn set_real_swapbuffers(context: SwapBufferIatContext) -> Result<(), Box<dyn Error>> {
+    let mut guard = REAL_SWAPBUFFERS.lock()?;
+    *guard = Some(context);
+    Ok(())
+}
+
+fn call_hooked_swapbuffers(handle: HANDLE) -> BOOL {
+    let mut guard = match REAL_SWAPBUFFERS.lock() {
+        Err(e) => {
+            log::error!("Failed to lock in swapbuffers. {e}");
+            return FALSE;
+        }
+        Ok(guard) => guard,
+    };
+
+    let ctx = match guard.as_mut() {
+        None => {
+            log::error!("Missing context. Cannot call SwapBuffers. Game is now broken");
+            panic!("Game broken");
+        }
+        Some(context) => context,
+    };
+
+    // Run the semi-global callback set up elsewhere
+    ctx.run_callback();
+
+    ctx.run_real_function(handle)
+}
+
+// Our hooked SwapBuffers implementation
+unsafe extern "system" fn my_swapbuffers(hdc: HDC) -> BOOL {
+    call_hooked_swapbuffers(hdc)
+}
+
+pub fn hook_swapbuffers(callback: SwapbufferCallback) -> Result<(), Box<dyn Error>> {
+    let store = install_plt_hook::<SwapBuffersFn>(
+        "swkotor.exe",
+        "SwapBuffers",
+        &(my_swapbuffers as SwapBuffersFn),
+    )?;
+
+    set_real_swapbuffers(SwapBufferIatContext {
+        iat_store: store,
+        iat_callback: callback,
+    })
+}

--- a/swkotor-mod/src/util/imgui.rs
+++ b/swkotor-mod/src/util/imgui.rs
@@ -1,0 +1,92 @@
+use std::error::Error;
+
+use crate::graphics::handle_load_with;
+use crate::graphics::rendering::Rendable;
+use imgui::*;
+use imgui_opengl_renderer::Renderer;
+
+struct ImgUiContext {
+    imgui: Option<Context>,
+    renderer: Option<Renderer>,
+}
+
+unsafe impl Send for ImgUiContext {}
+unsafe impl Sync for ImgUiContext {}
+
+pub struct ImguiRendable {
+    context: ImgUiContext,
+}
+
+unsafe impl Send for ImguiRendable {}
+unsafe impl Sync for ImguiRendable {}
+
+impl ImguiRendable {
+    pub fn new() -> Self {
+        Self {
+            context: ImgUiContext {
+                imgui: None,
+                renderer: None,
+            },
+        }
+    }
+}
+
+impl Rendable for ImguiRendable {
+    fn setup(&mut self) -> Result<(), Box<dyn Error>> {
+        if let None = self.context.imgui {
+            // Do not re-initialize imgui.
+            let mut imgui = Context::create();
+            // Disable saving state
+            imgui.set_ini_filename(None);
+            self.context.imgui = Some(imgui);
+        }
+
+        let imgui = self.context.imgui.as_mut().unwrap();
+
+        let renderer = Renderer::new(imgui, |s| {
+            // Does this need to actually be called every time?
+            handle_load_with(s)
+        });
+
+        self.context.renderer = Some(renderer);
+        Ok(())
+    }
+
+    fn render(&mut self, viewport_width: f32, viewport_height: f32) {
+        let context = &mut self.context;
+        let imgui = match &mut context.imgui {
+            None => {
+                log::trace!("Crash?! 3");
+                log::error!("Bug. Render called but imgui does not exist");
+                return;
+            }
+            Some(imgui) => imgui,
+        };
+
+        imgui.io_mut().display_size = [viewport_width, viewport_height];
+        let ui = imgui.frame();
+
+        let renderer = match &context.renderer {
+            None => {
+                log::error!("Bug. Render called but renderer does not exist");
+                return;
+            }
+            Some(renderer) => renderer,
+        };
+
+        // Draw a simple window
+        ui.window("Hello ImGui!")
+            .size([300.0, 100.0], Condition::Always)
+            .build(|| {
+                ui.text("This is a test ImGui window.");
+            });
+
+        // Render UI
+        renderer.render(imgui);
+    }
+
+    fn deinit(&mut self) {
+        // Drop renderer, but keep imgui
+        self.context.renderer = None;
+    }
+}

--- a/swkotor-mod/src/util/mod.rs
+++ b/swkotor-mod/src/util/mod.rs
@@ -2,3 +2,4 @@ pub mod iat;
 pub mod memory_patcher;
 pub mod needle_finder;
 pub mod poc;
+pub mod textdraw;

--- a/swkotor-mod/src/util/mod.rs
+++ b/swkotor-mod/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod iat;
+pub mod imgui;
 pub mod memory_patcher;
 pub mod needle_finder;
 pub mod poc;

--- a/swkotor-mod/src/util/poc.rs
+++ b/swkotor-mod/src/util/poc.rs
@@ -1,8 +1,10 @@
 /// Module that contains some hopefully obsoleting functions that
 /// are usable for debugging.
 ///
-
-use crate::{graphics::{initialize_pending_setup_rendering, RendingStore}, util};
+use crate::{
+    graphics::{initialize_pending_setup_rendering, RendingStore},
+    util,
+};
 
 use super::{imgui::ImguiRendable, textdraw::TextdrawRendable};
 
@@ -57,6 +59,13 @@ pub fn replace_resolution() {
 #[allow(dead_code)]
 pub fn draw_boxes_on_screen() -> RendingStore {
     let rendable = Box::new(TextdrawRendable::new());
+
+    initialize_pending_setup_rendering(rendable)
+}
+
+#[allow(dead_code)]
+pub fn draw_imgui() -> RendingStore {
+    let rendable = Box::new(ImguiRendable::new());
 
     initialize_pending_setup_rendering(rendable)
 }

--- a/swkotor-mod/src/util/poc.rs
+++ b/swkotor-mod/src/util/poc.rs
@@ -1,7 +1,10 @@
 /// Module that contains some hopefully obsoleting functions that
 /// are usable for debugging.
 ///
-use crate::util;
+
+use crate::{graphics::{initialize_pending_setup_rendering, RendingStore}, util};
+
+use super::{imgui::ImguiRendable, textdraw::TextdrawRendable};
 
 #[allow(dead_code)]
 pub fn replace_mouse_button_text() {
@@ -48,4 +51,12 @@ pub fn replace_resolution() {
         }
         log::trace!("Replaced {} instances", matches.len());
     }
+}
+
+/// Wrap the current graphics renderer here
+#[allow(dead_code)]
+pub fn draw_boxes_on_screen() -> RendingStore {
+    let rendable = Box::new(TextdrawRendable::new());
+
+    initialize_pending_setup_rendering(rendable)
 }

--- a/swkotor-mod/src/util/textdraw.rs
+++ b/swkotor-mod/src/util/textdraw.rs
@@ -1,0 +1,187 @@
+/// A PoC module that will just draw a square with some fake text in it
+///
+/// This assumes that swkotor uses old context/states from opengl,
+/// roughly meaning that it is able to fetch the context and draw by
+/// guessing the default state. It should work as it has been tested.
+///
+/// Note that at this moment, there is now actual text anywhere. It is
+/// just a fake one, drawing some squares instead of characters.
+///
+use gl::types::*;
+
+use crate::graphics::{opengl_bindings, rendering::Rendable};
+
+pub struct TextdrawContext {
+    font_text_id: GLuint,
+}
+
+unsafe impl Send for TextdrawContext {}
+unsafe impl Sync for TextdrawContext {}
+
+impl TextdrawContext {
+    // Call this once to create a simple texture in OpenGL
+    unsafe fn init_font_texture(&mut self) {
+        // In a real scenario, load a .png or .dds from memory or resource
+        // For brevity, let's pretend we have raw RGBA data or something.
+        // We'll do a placeholder that just creates a white texture.
+        let mut tex_id = 0;
+        gl::GenTextures(1, &mut tex_id);
+        gl::BindTexture(gl::TEXTURE_2D, tex_id);
+
+        // Some placeholder 8x8 white image
+        let pixels = vec![255u8; 8 * 8 * 4]; // RGBA=255 => white
+        gl::TexImage2D(
+            gl::TEXTURE_2D,
+            0,
+            gl::RGBA as GLint,
+            8,
+            8,
+            0,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            pixels.as_ptr() as *const _,
+        );
+
+        // Set texture parameters
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as i32);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as i32);
+
+        // Unbind
+        gl::BindTexture(gl::TEXTURE_2D, 0);
+
+        self.font_text_id = tex_id;
+    }
+
+    unsafe fn begin_2d_drawing(&self, viewport_width: f32, viewport_height: f32) {
+        // Save current matrices
+        opengl_bindings::MatrixMode(opengl_bindings::PROJECTION);
+        opengl_bindings::PushMatrix();
+        opengl_bindings::LoadIdentity();
+
+        // "Orthographic" from 0..viewport_width horizontally, 0..viewport_height vertically
+        // We'll assume (0,0) is the top-left, (width,height) is bottom-right, so invert the Y.
+        opengl_bindings::Ortho(
+            0.0,
+            viewport_width.into(),
+            viewport_height.into(),
+            0.0,
+            -1.0,
+            1.0,
+        );
+
+        opengl_bindings::MatrixMode(opengl_bindings::MODELVIEW);
+        opengl_bindings::PushMatrix();
+        opengl_bindings::LoadIdentity();
+
+        // Possibly disable depth test, enable alpha blending, etc.
+        gl::Disable(opengl_bindings::CULL_FACE);
+        gl::Disable(opengl_bindings::LIGHTING);
+        gl::Disable(gl::DEPTH_TEST);
+        gl::Enable(opengl_bindings::BLEND);
+        gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+    }
+
+    unsafe fn draw_text_private(&self, mut x: f32, y: f32, text: &str) {
+        // Bind our "font" texture
+        gl::BindTexture(gl::TEXTURE_2D, self.font_text_id);
+
+        gl::Enable(gl::TEXTURE_2D);
+
+        opengl_bindings::Color4f(1.0, 1.0, 1.0, 1.0); // White color
+
+        // Example: draw each character as an 8x8 quad, spaced 8 pixels
+        // We'll skip actual ASCII logic. We'll just draw N times for each char.
+        for (i, _ch) in text.chars().enumerate() {
+            // In real code, compute the glyph texture coords for the char
+
+            let r = if i % 2 == 0 { 1.0 } else { 0.0 };
+            let g = if i % 2 == 1 { 1.0 } else { 0.0 };
+            opengl_bindings::Color3f(r, g, 0.0);
+            let quad_size = 8.0;
+            let x2 = x + quad_size;
+            let y2 = y + quad_size;
+
+            opengl_bindings::Begin(gl::QUADS);
+            // top-left
+            opengl_bindings::TexCoord2f(0.0, 0.0);
+            opengl_bindings::Vertex2f(x, y);
+
+            // top-right
+            opengl_bindings::TexCoord2f(1.0, 0.0);
+            opengl_bindings::Vertex2f(x2, y);
+
+            // bottom-right
+            opengl_bindings::TexCoord2f(1.0, 1.0);
+            opengl_bindings::Vertex2f(x2, y2);
+
+            // bottom-left
+            opengl_bindings::TexCoord2f(0.0, 1.0);
+            opengl_bindings::Vertex2f(x, y2);
+            opengl_bindings::End();
+
+            x += quad_size; // Move for the next character
+        }
+
+        gl::Disable(gl::TEXTURE_2D);
+        gl::BindTexture(gl::TEXTURE_2D, 0);
+    }
+
+    unsafe fn end_2d_drawing(&self) {
+        // Restore everything
+        opengl_bindings::MatrixMode(opengl_bindings::MODELVIEW);
+        opengl_bindings::PopMatrix();
+        opengl_bindings::MatrixMode(opengl_bindings::PROJECTION);
+        opengl_bindings::PopMatrix();
+    }
+}
+
+pub struct TextdrawRendable {
+    context: Option<TextdrawContext>,
+}
+
+unsafe impl Send for TextdrawRendable {}
+unsafe impl Sync for TextdrawRendable {}
+
+impl TextdrawRendable {
+    pub fn new() -> Self {
+        Self { context: None }
+    }
+
+    fn set(&mut self, ctx: TextdrawContext) {
+        self.context = Some(ctx);
+    }
+
+    fn get(&mut self) -> &mut TextdrawContext {
+        match self.context.as_mut() {
+            Some(ctx) => ctx,
+            None => {
+                log::error!("Bug. Failed to get textdraw context.");
+                panic!("Bug. Failed to get textdraw context.");
+            }
+        }
+    }
+}
+
+impl Rendable for TextdrawRendable {
+    fn setup(self: &mut Self) -> Result<(), Box<dyn std::error::Error>> {
+        self.set(TextdrawContext { font_text_id: 0 });
+
+        unsafe {
+            self.get().init_font_texture();
+        }
+        Ok(())
+    }
+
+    fn render(self: &mut Self, viewport_width: f32, viewport_height: f32) {
+        unsafe {
+            let ctx = self.get();
+            ctx.begin_2d_drawing(viewport_width, viewport_height);
+            ctx.draw_text_private(0.0, 0.0, "Hello world");
+            ctx.end_2d_drawing();
+        };
+    }
+
+    fn deinit(self: &mut Self) {
+        todo!()
+    }
+}


### PR DESCRIPTION
# Summary

In future preparation for doing some rendering (maybe getting some live diagnostics), add possibility to do some simple renderings.

Imgui:

![Untitled](https://github.com/user-attachments/assets/67e7d522-2b25-47e0-8cd7-59050c69d46b)

Just some random boxes (placeholder text):

![image](https://github.com/user-attachments/assets/7f00ed45-dc4e-4e88-b6b3-3c75146fb56c)

The PR hooks to Windows' DRI's SwapBuffer function. In essence, it's called just before drawing the screen, so it's the best (and possible the onliest) place to draw something.

The screenshot above requires calling of `draw_boxes_on_screen` from poc.rs. Without it, nothing will be rendered.

# Testing

Imgui works in its current state whenever a movie is not playing (which should be fine). It's very intrusive when enabled but will not do anything if it isn't.

Box drawing works well in main menu, but possibly a shader leaks into the render code to cause wrong colours when getting to game.
